### PR TITLE
RSLIDER-133 #comment Fixed: bug on getEvent function in libraries/redevent/tags/tags.php

### DIFF
--- a/component/libraries/redevent/tags/tags.php
+++ b/component/libraries/redevent/tags/tags.php
@@ -481,7 +481,7 @@ class RedeventTags
 	{
 		if (empty($this->event))
 		{
-			$this->event = RModel::getFrontInstance('Eventhelper');
+			$this->event = RModel::getFrontInstance('Eventhelper', array('ignore_request' => true), 'com_redevent');
 			$this->event->setId($this->eventid);
 			$this->event->setXref($this->xref);
 		}


### PR DESCRIPTION
I've got an error with calling Eventhelper model in redSLIDER while trying to use replaceTags function of this helper
